### PR TITLE
Fixed emoji keyboard overlapping text field

### DIFF
--- a/JSQMessagesViewController.podspec
+++ b/JSQMessagesViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = 'JSQMessagesViewController'
-	s.version = '7.3.7'
+	s.version = '7.3.8'
 	s.summary = 'An elegant messages UI library for iOS.'
 	s.homepage = 'http://jessesquires.github.io/JSQMessagesViewController'
 	s.license = 'MIT'


### PR DESCRIPTION
Emoji keyboard has different height than english keyboard. Whenever keyboard’s frame changes, we should get notification with current keyboard height. However, there is a bug on iOS 11 so we don’t get this notification. Workaround is to animate keyboard frame to get updated height and then change position of text field. 
TUN-4928