### PR TITLE
TN-708 add method for providing cutom UIMenuItems

### DIFF
--- a/JSQMessagesViewController.podspec
+++ b/JSQMessagesViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = 'JSQMessagesViewController'
-	s.version = '9.0.1'
+	s.version = '9.1.0'
 	s.summary = 'An elegant messages UI library for iOS.'
 	s.homepage = 'http://jessesquires.github.io/JSQMessagesViewController'
 	s.license = 'MIT'

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -179,10 +179,6 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
 
     JSQMessagesCollectionViewLayoutAttributes *customAttributes = (JSQMessagesCollectionViewLayoutAttributes *)layoutAttributes;
 
-    if (self.textView.font != customAttributes.messageBubbleFont) {
-        self.textView.font = customAttributes.messageBubbleFont;
-    }
-
     if (!UIEdgeInsetsEqualToEdgeInsets(self.textView.textContainerInset, customAttributes.textViewTextContainerInsets)) {
         self.textView.textContainerInset = customAttributes.textViewTextContainerInsets;
     }

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
@@ -65,4 +65,9 @@
  */
 - (BOOL)hasText;
 
+/**
+ *  Custom Menu Items for UIMenuController when text in UITextView is selected.
+ */
+- (void)setCustomMenuItemsForCurrentSelectedText:(NSArray<UIMenuItem *> *)menuItems actionsTarget:(id)target;
+
 @end


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: ____

#### This fixes issue #___.

## What's in this pull request?

>...
It was impossible to add custom UIMenuItems to UIMenuController for selected text ion the application side, because implementation of JSQMessagesComposerTextView always clear custom menu items by setting nil to menuItems property [UIMenuController sharedMenuController].menuItems = nil. 
I removed this behaviour and added implementation of method for providing custom UIMenuItems to show. 
Basic problem with UIMenuItems is that during creation of object type UIMenuItem we can provide only selector for action (no way for specify target object). UIMenuController calls actions form its items on firstResponder object (in this case UITextView). To avoid implementing custom actions (application logic) in JSQ pod, I added implementation of forwarding menu items actions invocation from firstResponder to custom target (provided by application).
