### PR TITLE
TN-793 Implement adding customized menu items for text style options

### DIFF
--- a/JSQMessagesViewController.podspec
+++ b/JSQMessagesViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = 'JSQMessagesViewController'
-	s.version = '9.1.0'
+	s.version = '9.1.1'
 	s.summary = 'An elegant messages UI library for iOS.'
 	s.homepage = 'http://jessesquires.github.io/JSQMessagesViewController'
 	s.license = 'MIT'

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
@@ -69,5 +69,6 @@
  *  Custom Menu Items for UIMenuController when text in UITextView is selected.
  */
 - (void)setCustomMenuItemsForCurrentSelectedText:(NSArray<UIMenuItem *> *)menuItems actionsTarget:(id)target;
+- (void)setCustomMenuItemsForTextStyleOptions:(NSArray<UIMenuItem *> *)customTextStyleOptions actionsTarget:(id)target;
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -24,6 +24,7 @@
 
 @interface JSQMessagesComposerTextView()
 @property (nonatomic, strong) NSArray<UIMenuItem *> *customMenuItems;
+@property (nonatomic, strong) NSArray<UIMenuItem *> *customTextStyleOptions;
 @property (nonatomic, weak) id customTarget;
 @end
 
@@ -219,6 +220,11 @@
             return YES;
         }
     }
+    for (UIMenuItem *item in self.customTextStyleOptions) {
+        if (item.action == aSelector) {
+            return YES;
+        }
+    }
     return NO;
 }
 
@@ -240,10 +246,24 @@
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
+    
     if (!self.selectedTextRange.empty) {
+        
+        if ([self isTextStyleOptionsMenuItemSelected]) {
+            [UIMenuController.sharedMenuController setMenuItems:self.customTextStyleOptions];
+        }
+        
+        BOOL isActionTextStyleOptions = action == @selector(_showTextStyleOptions:);
+        BOOL areCustomTextStyleOptionsDefined = self.customTextStyleOptions != nil;
+        BOOL shouldDisplayTextStyleOptionsItem = isActionTextStyleOptions && areCustomTextStyleOptionsDefined && ![self hasTextStyleOptionsMenuItemCustomItems];
+        if (shouldDisplayTextStyleOptionsItem) {
+            return YES;
+        }
+        
         if (UIMenuController.sharedMenuController.menuItems == nil) {
             [UIMenuController.sharedMenuController setMenuItems:self.customMenuItems];
         }
+        
         if ([self isCustomMenuItemSelector:action]) {
             return YES;
         }
@@ -254,10 +274,34 @@
     return [super canPerformAction:action withSender:sender];
 }
 
+-(BOOL)isTextStyleOptionsMenuItemSelected {
+    NSArray<NSString*> *textStyleOptionsSelectors = @[@"toggleBoldface:", @"toggleItalics:", @"toggleUnderline:"];
+    for (UIMenuItem *menuItem in UIMenuController.sharedMenuController.menuItems) {
+        if ([textStyleOptionsSelectors containsObject:NSStringFromSelector(menuItem.action)]) {
+            return YES;
+        }
+    };
+    return NO;
+}
+
+-(BOOL)hasTextStyleOptionsMenuItemCustomItems {
+    for (UIMenuItem *menuItem in UIMenuController.sharedMenuController.menuItems) {
+        if ([self.customTextStyleOptions containsObject:menuItem]) {
+            return YES;
+        }
+    };
+    return NO;
+}
+
 - (void)setCustomMenuItemsForCurrentSelectedText:(NSArray<UIMenuItem *> *)menuItems actionsTarget:(id)target {
     self.customMenuItems = menuItems;
     self.customTarget = target;
     [UIMenuController.sharedMenuController update];
+}
+
+- (void)setCustomMenuItemsForTextStyleOptions:(NSArray<UIMenuItem *> *)customTextStyleOptions actionsTarget:(id)target {
+    self.customTextStyleOptions = customTextStyleOptions;
+    self.customTarget = target;
 }
 
 

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -253,9 +253,9 @@
             [UIMenuController.sharedMenuController setMenuItems:self.customTextStyleOptions];
         }
         
-        BOOL isActionTextStyleOptions = action == @selector(_showTextStyleOptions:);
+        BOOL isActionShowTextStyleOptions = action == @selector(_showTextStyleOptions:);
         BOOL areCustomTextStyleOptionsDefined = self.customTextStyleOptions.count > 0;
-        BOOL shouldDisplayTextStyleOptionsItem = isActionTextStyleOptions && areCustomTextStyleOptionsDefined && ![self textStyleOptionsMenuItemContainsCustomItems];
+        BOOL shouldDisplayTextStyleOptionsItem = isActionShowTextStyleOptions && areCustomTextStyleOptionsDefined && ![self textStyleOptionsMenuItemContainsCustomItems];
         if (shouldDisplayTextStyleOptionsItem) {
             return YES;
         }

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -280,7 +280,7 @@
         if ([textStyleOptionsSelectors containsObject:NSStringFromSelector(menuItem.action)]) {
             return YES;
         }
-    };
+    }
     return NO;
 }
 

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -254,8 +254,8 @@
         }
         
         BOOL isActionTextStyleOptions = action == @selector(_showTextStyleOptions:);
-        BOOL areCustomTextStyleOptionsDefined = self.customTextStyleOptions != nil;
-        BOOL shouldDisplayTextStyleOptionsItem = isActionTextStyleOptions && areCustomTextStyleOptionsDefined && ![self hasTextStyleOptionsMenuItemCustomItems];
+        BOOL areCustomTextStyleOptionsDefined = self.customTextStyleOptions.count > 0;
+        BOOL shouldDisplayTextStyleOptionsItem = isActionTextStyleOptions && areCustomTextStyleOptionsDefined && ![self textStyleOptionsMenuItemContainsCustomItems];
         if (shouldDisplayTextStyleOptionsItem) {
             return YES;
         }
@@ -284,12 +284,12 @@
     return NO;
 }
 
--(BOOL)hasTextStyleOptionsMenuItemCustomItems {
+-(BOOL)textStyleOptionsMenuItemContainsCustomItems {
     for (UIMenuItem *menuItem in UIMenuController.sharedMenuController.menuItems) {
         if ([self.customTextStyleOptions containsObject:menuItem]) {
             return YES;
         }
-    };
+    }
     return NO;
 }
 


### PR DESCRIPTION
To achieve adding our own text styles to "BIU" button following steps were taken:
1. New public method `setCustomMenuItemsForTextStyleOptions` has been added to set custom text style items outside library.
2. Inside `canPerformAction` function `isTextStyleOptionsMenuItemSelected` is called to check if user tapped "BIU" button. We can check if user tapped "BIU" button when in UIMenuController are 3 default text style items (@"toggleBoldface:", @"toggleItalics:", @"toggleUnderline:"). We need this information, because our goal is to override default text style menu items at this moment (bold, italic, underline) to our custom text style items.
3. In `canPerformAction` we also have to decide whether we show "BIU" button (`showTextStyleOptions` action) or not. To achieve this we need to check this time if UIMenuController has custom items. If that's true we are sure that we don't want to display "BIU" button. Also another conditions has to passed. We need to check if customItems are defined and of course action is equal to `showTextStyleOptions`.

This implementation ensure us that we can also add custom items like so far to UIMenuController regardless of whether we add a custom text style options or not.
