### PR TITLE
Prevent from allocating private api selector

### DIFF
--- a/JSQMessagesViewController.podspec
+++ b/JSQMessagesViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = 'JSQMessagesViewController'
-	s.version = '9.1.1'
+	s.version = '9.1.2'
 	s.summary = 'An elegant messages UI library for iOS.'
 	s.homepage = 'http://jessesquires.github.io/JSQMessagesViewController'
 	s.license = 'MIT'

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -245,25 +245,30 @@
     }
 }
 
+- (BOOL)isShowTextStyleOptionsSelector:(SEL)aSelector {
+    NSString *selectorName = NSStringFromSelector(aSelector);
+    return [selectorName containsString:@"showTextStyleOptions"];
+}
+
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
     
     if (!self.selectedTextRange.empty) {
-        
+
         if ([self isTextStyleOptionsMenuItemSelected]) {
             [UIMenuController.sharedMenuController setMenuItems:self.customTextStyleOptions];
         }
-        
-        BOOL isActionShowTextStyleOptions = action == @selector(_showTextStyleOptions:);
+
+        BOOL isShowTextStyleOptionsSelector = [self isShowTextStyleOptionsSelector:action];
         BOOL areCustomTextStyleOptionsDefined = self.customTextStyleOptions.count > 0;
-        BOOL shouldDisplayTextStyleOptionsItem = isActionShowTextStyleOptions && areCustomTextStyleOptionsDefined && ![self textStyleOptionsMenuItemContainsCustomItems];
+        BOOL shouldDisplayTextStyleOptionsItem = isShowTextStyleOptionsSelector && areCustomTextStyleOptionsDefined && ![self textStyleOptionsMenuItemContainsCustomItems];
         if (shouldDisplayTextStyleOptionsItem) {
             return YES;
         }
-        
+
         if (UIMenuController.sharedMenuController.menuItems == nil) {
             [UIMenuController.sharedMenuController setMenuItems:self.customMenuItems];
         }
-        
+
         if ([self isCustomMenuItemSelector:action]) {
             return YES;
         }


### PR DESCRIPTION
Avoid allocating private selector _showTextStyleOptions: for selectors comparison, use string comparison instead.